### PR TITLE
Moving req time into callback

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -97,24 +97,31 @@ app.get('*', (req, res) => {
 
   // tslint:disable-next-line:no-console
   console.time(`GET: ${req.originalUrl}`);
-  res.render('../dist/index', {
-    req: req,
-    res: res,
-    providers: [
-      {
-        provide: REQUEST, useValue: (req)
-      },
-      {
-        provide: RESPONSE, useValue: (res)
-      },
-      {
-        provide: 'ORIGIN_URL',
-        useValue: (`${http}://${req.headers.host}`)
-      }
-    ]
-  });
-  // tslint:disable-next-line:no-console
-  console.timeEnd(`GET: ${req.originalUrl}`);
+  res.render(
+    '../dist/index',
+    {
+      req: req,
+      res: res,
+      providers: [
+        {
+          provide: REQUEST, useValue: (req)
+        },
+        {
+          provide: RESPONSE, useValue: (res)
+        },
+        {
+          provide: 'ORIGIN_URL',
+          useValue: (`${http}://${req.headers.host}`)
+        }
+      ]
+    },
+    (err, html) => {
+      if (!!err) throw err;
+
+      // tslint:disable-next-line:no-console
+      console.timeEnd(`GET: ${req.originalUrl}`);
+      res.send(html);
+    });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
This should be more accurate.

One more thing, few lines on top of `res.render()`, you're setting the user agent globally:

```
global['navigator'] = req['headers']['user-agent'];
```

I'm not very confident with that. I don't have time to test, but I'm pretty sure there is a race condition here. ;)