### PR TITLE
Heroku deploy process PORT fix

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -123,6 +123,6 @@ app.get('*', (req, res) => {
     });
 });
 
-app.listen(PORT, () => {
+app.listen(process.env.PORT, () => {
   console.log(`listening on http://localhost:${PORT}!`);
 });


### PR DESCRIPTION
Просто маленькое наблюдение во время деплоя на хероку. Пока не добавил process.env.PORT, в проде не сервер не принимал запросы.

И еще, просто в качестве предложения - добавить небольшую инструкцию для деплоя на хероку. Мне помогли в канале телеграма, нужно изменить пару скриптов в package.json.

Спасибо. 