### PR TITLE
Reduce server bundles size and build time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11881,6 +11881,12 @@
         "lodash": "^4.17.5"
       }
     },
+    "webpack-node-externals": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
+      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==",
+      "dev": true
+    },
     "webpack-sources": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ssri": "6.0.0",
     "tslint": "5.10.0",
     "typescript": "2.7.2",
-    "webpack-cli": "3.0.8"
+    "webpack-cli": "3.0.8",
+    "webpack-node-externals": "^1.7.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,18 @@
 const path = require('path');
 const webpack = require('webpack');
+const nodeExternals = require('webpack-node-externals');
 /**
  * This is a server config which should be merged on top of common config
  */
 module.exports = {
   mode: 'development',
-  externals: [/(node_modules|main\..*\.js)/],
+  externals: [
+    nodeExternals({ whitelist: [
+      /\.(?!(?:jsx?|json)$).{1,5}$/i,
+      /ngx-cookie-service/
+    ] }),
+    /main\..*\.js/
+  ],
 
   entry: {
     // This is our Express server for Dynamic universal

--- a/yarn.lock
+++ b/yarn.lock
@@ -7246,6 +7246,10 @@ webpack-merge@^4.1.2:
   dependencies:
     lodash "^4.17.5"
 
+webpack-node-externals@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
+
 webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"


### PR DESCRIPTION
`server.js` and `prerender.js` bundles are huge and take long to build, because they're bloated with lots of dependencies from `node_modules`, and `externals: [/(node_modules|main\..*\.js)/]` regexp from `webpack.config.js` doesn't help.
But the [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) module can reduce bundle size from 5.61 MiB to 83 KiB, and build time from 2391ms to 196ms!

*I was looking for a solution for several hours, before I noticed this great starter. Now it may become even better! \o/