### PR TITLE
Fixed bug with prerender on Windows system

### DIFF
--- a/prerender.ts
+++ b/prerender.ts
@@ -62,8 +62,10 @@ ROUTES.forEach((route) => {
   if (!existsSync(fullPath)) {
     let syncpath = BROWSER_FOLDER;
     route.split('/').forEach((element) => {
-      syncpath = syncpath + '/' + element;
-      mkdirSync(syncpath);
+      syncpath = join(syncpath, element);
+      if (!existsSync(syncpath)) {
+        mkdirSync(syncpath);
+      }
     });
   }
 


### PR DESCRIPTION
При сборке prerender в windows появляется ошибка 

Error: EEXIST: file already exists, mkdir 'D:\angular\project\static'

Файл static.paths.ts:
`export const ROUTES = ['/static/back', '/home'];`

Результат следующего кода:

```
const fullPath = join(BROWSER_FOLDER, route);
  console.log(fullPath);

  // Make sure the directory structure is there
  if (!existsSync(fullPath)) {
    let syncpath = BROWSER_FOLDER;
    route.split('/').forEach((element) => {
      syncpath = syncpath + '/' + element;
      console.log(syncpath);
      mkdirSync(syncpath);
    });
  }
```

```
D:\angular\project\static\static\back
D:\angular\project\static/
D:\angular\project\static//static
D:\angular\project\static//static/back
D:\angular\project\static\home
D:\angular\project\static/
```